### PR TITLE
Avoid: MSVC 以外で作成するバイナリでは YMM の利用を避ける

### DIFF
--- a/yomita/yomita/src/genmove.cpp
+++ b/yomita/yomita/src/genmove.cpp
@@ -34,7 +34,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // 持ち駒打ちでAVX2命令を使うか
 #ifdef HAVE_BMI2
+// MSVC で無い場合は、YMM を使用しない
+#if defined(_MSC_VER)
 #define USE_YMM
+#endif
 #endif
 
 // プロトタイプ宣言 : generateLegalのため


### PR DESCRIPTION
(こうった対応でコードを動かすのが良くない場合は、リジェクトしてください)

すみません、AVX2を使用したLinux版がうまく動作していませんでした。
具体的には、`genmove.cpp` の `_mm256_or_si256()` を使用している箇所です。

以下は、その追跡用のコードで、
https://gist.github.com/ohga/d547f47e40a5b733be30d60543583779#file-genmove-cpp-L532
の箇所で SIGSEGV が発生してしまいます。

上記コードを gdb て動かしてみた時のログが以下です。
https://gist.github.com/ohga/208b0d631bb1f23c549fee8304ec00ea

L72, L74, L76 で変数をダンプしていますが、変な値では無さそうな気はするので、`*(__m256i*)mlist = _mm256_or_si256(s1, s2);` の箇所をコンパイラがうまく解釈できてない気がしています。

少し考えてみましたが、最適なコードが思いつかなかったので、対処療法として、MSVC じゃ無い場合は、`genmove.cpp` の `USE_YMM` を使わないとする PR です。