### PR TITLE
LinuxでのAVX2のアライメントの問題の対応とテストコードの下書きの追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ script:
   - mkdir "$TRAVIS_BUILD_DIR/build-ninja-$TARGET"
   - cd "$TRAVIS_BUILD_DIR/build-ninja-$TARGET"
   - cmake -Dtarget=$TARGET -G Ninja "$SRC_DIR" && ninja -v
-  - 'if [ "$TARGET" = "avx2" ]; then wget https://github.com/TukamotoRyuzo/Yomita/releases/download/SDT5/yomitaSDT5.zip && unzip yomitaSDT5.zip && mv Yomita-by-clang yomita_engine && cd yomita_engine && echo usi | ./Yomita-by-clang && echo b | ./Yomita-by-clang; fi'
-  - 'if [ "$TARGET" = "sse42" ]; then wget https://github.com/TukamotoRyuzo/Yomita/releases/download/SDT5/yomitaSDT5.zip && unzip yomitaSDT5.zip && mv Yomita-by-clang yomita_engine && cd yomita_engine && echo usi | ./Yomita-by-clang && echo b | ./Yomita-by-clang; fi'
-  - 'if [ "$TARGET" = "learn" ]; then wget https://github.com/TukamotoRyuzo/Yomita/releases/download/SDT5/yomitaSDT5.zip && unzip yomitaSDT5.zip && mv Yomita-by-clang yomita_engine && cd yomita_engine && echo usi | ./Yomita-by-clang && echo b | ./Yomita-by-clang; fi'
-  - 'if [ "$TARGET" = "learn-sse42" ]; then wget https://github.com/TukamotoRyuzo/Yomita/releases/download/SDT5/yomitaSDT5.zip && unzip yomitaSDT5.zip && mv Yomita-by-clang yomita_engine && cd yomita_engine && echo usi | ./Yomita-by-clang && echo b | ./Yomita-by-clang; fi'
-# - 'if [ -f "Yomita-by-clang" && "$TARGET" = "avx2" ]; then
+  - mv Yomita-by-clang ../../../tests/
+  - cd ../../../tests/
+  - ./all.sh $TARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+language: cpp
+os: linux
+dist: trusty
+sudo: required
+compiler: clang
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-trusty-3.9
+    packages:
+      - clang-3.9
+      - g++-6
+      - libc++-dev
+      - ninja-build
+      - cmake
+      - cmake-data
+env:
+  global:
+    - CC='clang-3.9'
+    - CXX='clang++-3.9'
+  matrix:
+    - TARGET=avx2
+    - TARGET=sse42
+    - TARGET=learn
+    - TARGET=learn-sse42
+
+before_install:
+  - env
+  - cat /proc/cpuinfo
+  - export SRC_DIR="`pwd`/yomita/yomita/src"
+script:
+  - pwd
+  - echo $TARGET
+  - mkdir "$TRAVIS_BUILD_DIR/build-ninja-$TARGET"
+  - cd "$TRAVIS_BUILD_DIR/build-ninja-$TARGET"
+  - cmake -Dtarget=$TARGET -G Ninja "$SRC_DIR" && ninja -v
+  - 'if [ "$TARGET" = "avx2" ]; then wget https://github.com/TukamotoRyuzo/Yomita/releases/download/SDT5/yomitaSDT5.zip && unzip yomitaSDT5.zip && mv Yomita-by-clang yomita_engine && cd yomita_engine && echo usi | ./Yomita-by-clang && echo b | ./Yomita-by-clang; fi'
+  - 'if [ "$TARGET" = "sse42" ]; then wget https://github.com/TukamotoRyuzo/Yomita/releases/download/SDT5/yomitaSDT5.zip && unzip yomitaSDT5.zip && mv Yomita-by-clang yomita_engine && cd yomita_engine && echo usi | ./Yomita-by-clang && echo b | ./Yomita-by-clang; fi'
+  - 'if [ "$TARGET" = "learn" ]; then wget https://github.com/TukamotoRyuzo/Yomita/releases/download/SDT5/yomitaSDT5.zip && unzip yomitaSDT5.zip && mv Yomita-by-clang yomita_engine && cd yomita_engine && echo usi | ./Yomita-by-clang && echo b | ./Yomita-by-clang; fi'
+  - 'if [ "$TARGET" = "learn-sse42" ]; then wget https://github.com/TukamotoRyuzo/Yomita/releases/download/SDT5/yomitaSDT5.zip && unzip yomitaSDT5.zip && mv Yomita-by-clang yomita_engine && cd yomita_engine && echo usi | ./Yomita-by-clang && echo b | ./Yomita-by-clang; fi'
+# - 'if [ -f "Yomita-by-clang" && "$TARGET" = "avx2" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,13 @@ before_install:
   - env
   - cat /proc/cpuinfo
   - export SRC_DIR="`pwd`/yomita/yomita/src"
+  - export TEST_DIR="`pwd`/tests"
 script:
   - pwd
   - echo $TARGET
   - mkdir "$TRAVIS_BUILD_DIR/build-ninja-$TARGET"
   - cd "$TRAVIS_BUILD_DIR/build-ninja-$TARGET"
   - cmake -Dtarget=$TARGET -G Ninja "$SRC_DIR" && ninja -v
-  - mv Yomita-by-clang ../../../tests/
-  - cd ../../../tests/
+  - mv Yomita-by-clang "$TEST_DIR"
+  - cd $TEST_DIR
   - ./all.sh $TARGET

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # 読み太
+ [![Build Status](https://travis-ci.org/ohga/Yomita.svg?branch=master)](https://travis-ci.org/ohga/Yomita)
 
 読み太はUSIプロトコル準拠の将棋エンジンです。  
 主にチェスエンジンのStockfishをベースとし、  

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # 読み太
- [![Build Status](https://travis-ci.org/ohga/Yomita.svg?branch=master)](https://travis-ci.org/ohga/Yomita)
+ [![Build Status](https://travis-ci.org/TukamotoRyuzo/Yomita.svg?branch=master)](https://travis-ci.org/TukamotoRyuzo/Yomita)
 
 読み太はUSIプロトコル準拠の将棋エンジンです。  
 主にチェスエンジンのStockfishをベースとし、  

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+#if [ "x$1" != "xsse42" ]; then
+if [ "x$1" != "xsse42" || "x$1" != "xavx2" ]; then
+  echo "testing cancel(!= $1)"
+  exit 0
+fi
+
+echo "testing started"
+pwd
+
+wget https://github.com/TukamotoRyuzo/Yomita/releases/download/SDT5/yomitaSDT5.zip -O yomitaSDT5.zip
+if [ $? != 0 ]; then
+  echo "testing failed(wget)"
+  exit 1
+fi
+
+unzip -o yomitaSDT5.zip
+if [ $? != 0 ]; then
+  echo "testing failed(unzip)"
+  exit 1
+fi
+
+mv ./yomita_engine/* ./
+
+echo "loading eval.bin.."
+cat eval/kppt/*.bin eval/kppt/*/*.bin > /dev/null 2>&1
+
+./perft.sh
+./moves.sh
+
+

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-#if [ "x$1" != "xsse42" ]; then
-if [ "x$1" != "xsse42" || "x$1" != "xavx2" ]; then
+if [ "x$1" != "xsse42" ]; then
   echo "testing cancel(!= $1)"
   exit 0
 fi

--- a/tests/moves.sh
+++ b/tests/moves.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+error()
+{
+  echo "moves testing failed on line $1"
+  exit 1
+}
+trap 'error ${LINENO}' ERR
+
+echo "moves testing started"
+
+(
+  echo "isready";
+  echo "usinewgame";
+  echo "position startpos moves 7g7f";
+  echo "go btime 0 wtime 0 byoyomi 5000";
+  sleep 6;
+  echo "position startpos moves 7g7f 8c8d 8h7g";
+  echo "go btime 0 wtime 0 byoyomi 5000";
+  sleep 6;
+  echo "position startpos moves 7g7f 8c8d 8h7g 4a3b 3i3h";
+  echo "go btime 0 wtime 0 byoyomi 5000";
+  sleep 6;
+) | ./Yomita-by-clang | tee result.txt
+
+
+# resignを除くbestmoveの応答が3つ無い場合は失敗
+rtn=`grep -v resign result.txt | grep bestmove | wc -l`
+if [ "x${rtn}" != "x3" ]; then
+  echo "moves testing failed(bestmove?)"
+  exit 1
+fi
+
+rm result.txt
+echo "---"
+echo "moves testing OK"
+

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+error()
+{
+  echo "perft testing failed on line $1"
+  exit 1
+}
+trap 'error ${LINENO}' ERR
+
+echo "perft testing started"
+
+keys=("nodes" "captures" "promotions" "checks" "checkmates");
+
+# start pos で 1 から 5 まで
+for nn in {1..5}; do
+  echo "----- perft $nn START_POS -----";
+  ./Yomita-by-clang << END_OF_USI > result.txt
+isready
+position startpos
+perft $nn
+END_OF_USI
+  for str in "${keys[@]}"; do
+    grep $str result.txt
+  done;
+done;
+
+# max で 1 から 3 まで
+for nn in {1..3}; do
+  echo "----- perft $nn MAX_MOVES_POS -----";
+  ./Yomita-by-clang << END_OF_USI > result.txt
+max
+perft $nn
+END_OF_USI
+  for str in "${keys[@]}"; do
+    grep $str result.txt
+  done;
+done;
+
+rm result.txt
+echo "---"
+echo "perft testing OK"
+

--- a/yomita/yomita/src/CMakeLists.txt
+++ b/yomita/yomita/src/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 2.8)
+set(CMAKE_CXX_COMPILER "clang++")
+add_definitions("-std=c++14 -fno-exceptions -fno-rtti -Wextra -Ofast -MMD -MP")
+add_definitions("-Wno-unused-parameter")
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,-s -v")
+
+if(NOT DEFINED target)
+   set(target "avx2")
+endif()
+if(target STREQUAL avx2)
+  add_definitions("-DNDEBUG -DHAVE_BMI2 -DHAVE_SSE4 -mbmi2 -mavx2 -march=corei7-avx")
+elseif(target STREQUAL sse42)
+  add_definitions("-DNDEBUG -DHAVE_SSE42 -msse4.2 -march=corei7")
+elseif(target STREQUAL learn)
+  add_definitions("-DHAVE_BMI2 -DLEARN -DHAVE_SSE4 -mbmi2 -mavx2 -march=corei7-avx")
+elseif(target STREQUAL learn-sse42)
+  add_definitions("-DHAVE_SSE42 -DLEARN -mbmi2 -mavx2 -march=corei7-avx")
+elseif(DEFINED target)
+  message(FATAL_ERROR "invalid target")
+endif()
+
+set(sources
+  benchmark.cpp
+  bitboard.cpp
+  bitboard.h
+  bitop.h
+  board.cpp
+  board.h
+  book.cpp
+  book.h
+  byteboard.cpp
+  byteboard.h
+  common.cpp
+  common.h
+  config.h
+  enumoperator.h
+  eval_kppt.cpp
+  eval_ppt.cpp
+  eval_pptp.cpp
+  eval_util.cpp
+  evalsum.h
+  evaluate.h
+  genmove.cpp
+  haffman.cpp
+  hand.h
+  learn.cpp
+  learn.h
+  main.cpp
+  move.h
+  movepick.cpp
+  movepick.h
+  platform.h
+  pretty.cpp
+  progress.cpp
+  progress.h
+  range.h
+  search.cpp
+  search.h
+  sfen_rw.cpp
+  sfen_rw.h
+  test.cpp
+  thread.cpp
+  thread.h
+  timeman.cpp
+  timeman.h
+  tt.cpp
+  tt.h
+  types.h
+  usi.cpp
+  usi.h
+  usioption.cpp
+)
+add_executable(Yomita-by-clang ${sources})
+target_link_libraries(Yomita-by-clang stdc++fs pthread)
+

--- a/yomita/yomita/src/Makefile
+++ b/yomita/yomita/src/Makefile
@@ -56,7 +56,7 @@ $(OBJDIR)/%.o: %.cpp
 all: clean $(TARGET)
 
 avx2:
-	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DHAVE_BMI2 -mbmi2 -mavx2 -march=corei7-avx' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
+	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DHAVE_BMI2 -DHAVE_SSE4 -mbmi2 -mavx2 -march=corei7-avx' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
 
 sse42:
 	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DHAVE_SSE42 -msse4.2 -march=corei7' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
@@ -65,7 +65,7 @@ sse42:
 # 	$(MAKE) CFLAGS='$(CFLAGS) -DNDEBUG -DHAVE_SSE2 -msse2 -march=core2' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)_sse
 
 learn:
-	$(MAKE) CFLAGS='$(CFLAGS) -DHAVE_BMI2 -DLEARN -mbmi2 -mavx2 -march=corei7-avx' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
+	$(MAKE) CFLAGS='$(CFLAGS) -DHAVE_BMI2  -DHAVE_SSE4 -DLEARN -mbmi2 -mavx2 -march=corei7-avx' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)
 
 learn-sse42:
 	$(MAKE) CFLAGS='$(CFLAGS) -DHAVE_SSE42 -DLEARN -mbmi2 -mavx2 -march=corei7-avx' LDFLAGS='$(LDFLAGS) $(LTOFLAGS)' $(TARGET)

--- a/yomita/yomita/src/board.cpp
+++ b/yomita/yomita/src/board.cpp
@@ -358,6 +358,7 @@ Bitboard Board::attackers(const Square sq, const Bitboard& occupied) const
 }
 
 template Bitboard Board::attackers<true>(const Turn t, const Square sq, const Bitboard& occupied) const;
+template Bitboard Board::attackers<false>(const Turn t, const Square sq, const Bitboard& occupied) const;
 
 // sqに移動可能な手番側の駒のBitboardを返す。
 template <bool ExceptKing> Bitboard Board::attackers(const Turn t, const Square sq, const Bitboard& occupied) const


### PR DESCRIPTION
* ビルド時のターゲット avx2, learn については `-DHAVE_SSE4` を追加しました。
* リンカでエラーが発生する為 `Bitboard Board::attackers<false>` を追加しました。
* Linux バイナリの正常性の確認の自動化を目的とし、`tests/` にコードを作成、 Travis CI の為の定義ファイルを追加しました。(現状は target sse42 の時のみ発火します。)
